### PR TITLE
Added force attribute for mkdocs gh-deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This action can be configured by setting the following `env` varibles
 | **GITHUB_DOMAIN**  | `github.com`          | Specify a custom Github domain in case Github Enterprise is used: e.g. `github.myenterprise.com`. |
 | **ACTOR**          | `author of PR/commit` | Overwrite the author of the PR/commit.                                                            |
 | **REQUIREMENTS**   | `requirements.txt`    | Specify a custom `requirements.txt` file to use custom Python modules.                            |
+| **FORCE**          | `"true"`              | Force defines if the `mkdocs` build artefacts should be force pushed into the `gh-pages` |
 
 ## Using custom modules
 
@@ -76,9 +77,9 @@ Create a corresponding file containing a versioned list of those modules (`pip f
 setting the `REQUIREMENTS` environment variable.
 
 ```yaml
-      - name: Deploy docs
-        uses: afritzler/mkdocs-gh-pages-action@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REQUIREMENTS: myawesome-requirements.txt
+- name: Deploy docs
+  uses: afritzler/mkdocs-gh-pages-action@main
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    REQUIREMENTS: myawesome-requirements.txt
 ```

--- a/action.sh
+++ b/action.sh
@@ -45,4 +45,8 @@ fi
 git remote rm origin
 git remote add origin "${remote_repo}"
 
-mkdocs gh-deploy --config-file "${CONFIG_FILE}" --force
+if [ "${FORCE}" = "false" ]; then
+    mkdocs gh-deploy --config-file "${CONFIG_FILE}"
+else
+    mkdocs gh-deploy --config-file "${CONFIG_FILE}" --force
+fi


### PR DESCRIPTION
# Proposed Changes

- Introduced `FORCE` environment variable to disable `mkdocs` force publishing to the `gh-pages` branch.
